### PR TITLE
Alpine linux build error fix

### DIFF
--- a/tools/flock/src/flock.c
+++ b/tools/flock/src/flock.c
@@ -39,6 +39,7 @@
 #include <sys/file.h>
 #include <sys/time.h>
 #include <sys/wait.h>
+#include <fcntl.h>
 
 #define PACKAGE_STRING "util-linux-ng 2.18"
 #define _(x) (x)


### PR DESCRIPTION
build errors fix:
src/flock.c:208:34: error: 'O_NOCTTY' undeclared (first use in this function)
     fd = open(filename, O_RDONLY|O_NOCTTY|O_CREAT, 0666);
src/flock.c:208:43: error: 'O_CREAT' undeclared (first use in this function)
     fd = open(filename, O_RDONLY|O_NOCTTY|O_CREAT, 0666);

Signed-off-by: Ruslan Isaev <legale.legale@gmail.com>